### PR TITLE
Railtie detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.gem
+*.iml
 *.rbc
 .bundle
 .config
+.idea
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/sucker_punch.rb
+++ b/lib/sucker_punch.rb
@@ -54,4 +54,4 @@ at_exit do
   SuckerPunch::Queue.shutdown_all
 end
 
-require 'sucker_punch/railtie' if defined?(::Rails)
+require 'sucker_punch/railtie' if defined?(::Rails) && defined?(::Rails::Railtie)


### PR DESCRIPTION
The `Rails` namespace may be available, but not necessarily the `Rails::Railtie` namespace.

do **NOT** merge, need test coverage. note to self for upstream PR.
